### PR TITLE
Fixed username_claim behavior & bumped dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # express-jwt-pouchdb
 
+This forked variant of express-jwt-pouchdb brings express-pouch up to date and also makes the username_claim configuration behave as intended by couch_jwt_auth.  See https://github.com/tyler-johnson/express-jwt-pouchdb/pull/4.
+
 [![npm](https://img.shields.io/npm/v/express-jwt-pouchdb.svg)](https://www.npmjs.com/package/express-jwt-pouchdb) [![David](https://img.shields.io/david/tyler-johnson/express-jwt-pouchdb.svg)](https://david-dm.org/tyler-johnson/express-jwt-pouchdb) [![Build Status](https://travis-ci.org/tyler-johnson/express-jwt-pouchdb.svg?branch=master)](https://travis-ci.org/tyler-johnson/express-jwt-pouchdb)
 
 [Express-PouchDB](http://ghub.io/express-pouchdb) clone with [JSON Web Token](https://jwt.io) support. This is designed to mimic the [couch_jwt_auth](https://github.com/softapalvelin/couch_jwt_auth) plugin for CouchDB so it can serve as a testing server. Configuration and usage matches that plugin.

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test-couchdb": "./bin/test-couchdb.sh"
   },
   "dependencies": {
-    "express": "^4.13.4",
-    "express-pouchdb": "^1.0.3",
+    "express": "^4.14.1",
+    "express-pouchdb": "^4.2.0",
     "jsonwebtoken": "^7.0.1",
     "memdown": "^1.1.2",
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "express-jwt-pouchdb",
-  "version": "0.0.0-edge",
+  "name": "@inator/express-jwt-pouchdb",
+  "version": "1.0.0",
   "description": "Express-PouchDB with JSON Web Token Support.",
-  "author": "Tyler Johnson <tyler@tylerjohnson.me>",
+  "author": "Orginal: Tyler Johnson <tyler@tylerjohnson.me>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tyler-johnson/express-jwt-pouchdb.git"
+    "url": "https://github.com/inator/express-jwt-pouchdb"
   },
   "main": "index.js",
   "bin": "cli.js",

--- a/src/jwt-auth.js
+++ b/src/jwt-auth.js
@@ -39,10 +39,12 @@ export default function(pouchapp) {
 			return utils.sendError(res, e, 401);
 		}
 
-		if (typeof payload.name !== "string") payload.name = null;
+        let userNameClaim = pouchapp.couchConfig.get("jwt_auth", "username_claim");
+
+		if (typeof payload[userNameClaim] !== "string") payload[userNameClaim] = null;
 		if (!Array.isArray(payload.roles)) payload.roles = [];
 
-		req.couchSession.userCtx.name = payload.name;
+		req.couchSession.userCtx.name = payload[userNameClaim];
 		req.couchSession.userCtx.roles = payload.roles;
 		req.couchSession.info.authenticated = "jwt";
 


### PR DESCRIPTION
Hello @tyler-johnson - please consider this pull request which brings express-pouch up to date and also makes the username_claim configuration behave as intended by [couch_jwt_auth](https://github.com/softapalvelin/couch_jwt_auth/wiki/Configuration-options#username_claim).